### PR TITLE
Switched from CGFLOAT_MAX to HUGE_VALF

### DIFF
--- a/src/core/DRPLoadingSpinner.m
+++ b/src/core/DRPLoadingSpinner.m
@@ -249,7 +249,7 @@
         rotationAnimation.toValue = @(rotationStartRadians + (2 * M_PI));
         rotationAnimation.timingFunction = [DRPLoadingSpinnerTimingFunction linear];
         rotationAnimation.duration = self.rotationCycleDuration;
-        rotationAnimation.repeatCount = CGFLOAT_MAX;
+        rotationAnimation.repeatCount = HUGE_VALF;
         rotationAnimation.fillMode = kCAFillModeForwards;
 
         [layer removeAnimationForKey:@"rotation"];


### PR DESCRIPTION
Switched from CGFLOAT_MAX to HUGE_VALF so that XCode 9's 'Undefined Behaviour Sanitizer' does not report an issue. (this is what old documentation pre-swift used to specify for repeat forever according to: https://stackoverflow.com/a/7082640/127853).